### PR TITLE
fix(build-iso): retry on transient network errors, fail fast on real errors

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -252,9 +252,30 @@ jobs:
 
       - name: Build disk image
         run: |
-          mkosi --force --image-version=${{ steps.version.outputs.version }} || \
-            (echo "Retrying..." && sleep 10 && \
-             mkosi --force --image-version=${{ steps.version.outputs.version }})
+          # Retry wrapper: only retries on transient network errors (mirror
+          # unreachable, DNS failure, curl timeout). Non-network errors
+          # (package conflict, missing dependency, GPG check) fail immediately.
+          retry_if_unreachable() {
+            local max_attempts=3 backoff=30 attempt=1 logfile
+            logfile=$(mktemp)
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if "$@" 2>&1 | tee "$logfile"; then
+                rm -f "$logfile"; return 0
+              fi
+              if grep -qiE 'curl error \(([67]|28)\)|could not connect|connection refused|timed out|all mirrors were tried|network is unreachable|name or service not known|failed to connect.*port' "$logfile"; then
+                echo "::warning::Network error on attempt $attempt/$max_attempts, retrying in ${backoff}s..."
+                sleep "$backoff"
+                attempt=$((attempt + 1))
+              else
+                echo "::error::Non-network build error — not retrying"
+                rm -f "$logfile"; return 1
+              fi
+            done
+            echo "::error::Network error persisted after $max_attempts attempts"
+            rm -f "$logfile"; return 1
+          }
+
+          retry_if_unreachable mkosi --force --image-version=${{ steps.version.outputs.version }}
 
       - name: Convert and compress
         env:
@@ -353,7 +374,29 @@ jobs:
           gpgcheck=0
           EOF
 
-          dnf install -y \
+          # RPMFusion mirrors are occasionally unreachable — retry on
+          # transient network errors only, fail fast on real dnf errors.
+          retry_if_unreachable() {
+            local max_attempts=3 backoff=30 attempt=1 logfile
+            logfile=$(mktemp)
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if "$@" 2>&1 | tee "$logfile"; then
+                rm -f "$logfile"; return 0
+              fi
+              if grep -qiE 'curl error \(([67]|28)\)|could not connect|connection refused|timed out|all mirrors were tried|network is unreachable|name or service not known|failed to connect.*port' "$logfile"; then
+                echo "::warning::Network error on attempt $attempt/$max_attempts, retrying in ${backoff}s..."
+                sleep "$backoff"
+                attempt=$((attempt + 1))
+              else
+                echo "::error::Non-network dnf error — not retrying"
+                rm -f "$logfile"; return 1
+              fi
+            done
+            echo "::error::Network error persisted after $max_attempts attempts"
+            rm -f "$logfile"; return 1
+          }
+
+          retry_if_unreachable dnf install -y \
             https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-43.noarch.rpm \
             https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-43.noarch.rpm
 
@@ -404,7 +447,11 @@ jobs:
           # Use netinst as base (~700 MB) instead of Workstation Live (~2.2 GB)
           # The netinst has Anaconda installer; our local repo provides all packages
           ISO_NAME="Fedora-Everything-netinst-${ARCH}-43-1.6.iso"
-          curl -L -o /tmp/fedora-netinst.iso \
+
+          # curl with retry — Fedora mirrors are generally reliable but
+          # CDN edge nodes occasionally return transient errors.
+          curl --retry 3 --retry-delay 15 --retry-connrefused \
+            -L -o /tmp/fedora-netinst.iso \
             "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Everything/${ARCH}/iso/${ISO_NAME}"
 
       - name: Build self-contained offline ISO


### PR DESCRIPTION
Hardens the reusable `build-iso.yml` against transient mirror outages that caused the v0.4.35 kiosk release to fail on 2/10 variants tonight (atomic + Disk Images, both aarch64).

## Root cause

RPMFusion mirrors returned `Curl error (7): Could not connect` for ~2 minutes during the release build. The old retry logic in the mkosi step was a blind "retry once after 10s on ANY failure" — insufficient for sustained outages, wasteful for real errors.

## Fix

New \`retry_if_unreachable\` wrapper function (defined inline, 15 lines) that:
- Retries up to **3 times with 30s backoff** on network errors only
- Matches: \`Curl error (6|7|28)\`, \`Could not connect\`, \`All mirrors were tried\`, \`Network is unreachable\`, \`connection refused\`, \`timed out\`, DNS failures
- **Fails immediately** on non-network errors (missing package, dependency conflict, GPG check)
- Streams output normally via \`tee\` — no buffering surprise

Applied to the 3 build steps most vulnerable to mirror flakes:
1. RPMFusion \`dnf install\` in the Offline ISO job ← tonight's failure
2. \`mkosi --force\` in the Disk Images job ← replaces old blind retry
3. Fedora ISO download (\`curl\`) ← added native \`--retry 3 --retry-connrefused\`

## Not changed

- "Download all packages for offline install" — already has \`|| true\` (partial downloads are usable)
- dnf's own config (\`retries=5 timeout=120\`) — already present, orthogonal

## Testing

Re-ran the failing aarch64 Offline ISO job after RPMFusion came back → succeeded immediately. This fix prevents the need for manual re-runs in future mirror outages.