### PR TITLE
fix(build-iso): patch ALL grub.cfg paths in the ISO, not just /EFI/BOOT

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -516,16 +516,47 @@ jobs:
           # Post-mkksiso: patch grub.cfg (same approach as netinstall)
           if [ -n "$ISO_GRUB_FILE" ] && [ -f "$ISO_GRUB_FILE" ]; then
             echo "Patching grub.cfg in ISO with $ISO_GRUB_FILE"
+            # Fedora ISOs ship TWO grub.cfg files that we must BOTH
+            # replace to stop the "Install Fedora 43" menu from leaking
+            # through on one boot path while the xiboplayer menu shows
+            # on another:
+            #
+            #   /EFI/BOOT/grub.cfg      — Secure Boot UEFI path (shim
+            #                              → grubx64.efi reads this)
+            #   /boot/grub2/grub.cfg    — BIOS eltorito + some UEFI
+            #                              paths read this one
+            #
+            # Previously we only patched /EFI/BOOT/grub.cfg, so BIOS
+            # boots + certain UEFI setups saw the unmodified Fedora
+            # menu. Discover any additional grub.cfg paths at runtime
+            # and map them ALL in a single xorriso session (cheaper
+            # than running xorriso per file).
+            #
             # -outdev must be a FRESH file (xorriso refuses to write
             # to a non-empty file that differs from -indev). Write to
             # .tmp then mv back.
-            xorriso -indev "$ISO_OUT" \
-              -outdev "${ISO_OUT}.tmp" \
-              -boot_image any replay \
-              -map "$ISO_GRUB_FILE" /EFI/BOOT/grub.cfg \
-              -end
-            mv "${ISO_OUT}.tmp" "$ISO_OUT"
-            echo "grub.cfg patched successfully"
+            mapfile -t GRUB_CFG_PATHS < <(
+              xorriso -indev "$ISO_OUT" \
+                -find / -name 'grub.cfg' 2>/dev/null \
+                | awk "/^'\\/.*grub\\.cfg'\$/ { gsub(/'/,\"\"); print }"
+            )
+            if [ "${#GRUB_CFG_PATHS[@]}" -eq 0 ]; then
+              echo "WARNING: no grub.cfg paths found in $ISO_OUT — skipping patch"
+            else
+              echo "Found ${#GRUB_CFG_PATHS[@]} grub.cfg path(s):"
+              printf '  - %s\n' "${GRUB_CFG_PATHS[@]}"
+              XORRISO_MAPS=()
+              for path in "${GRUB_CFG_PATHS[@]}"; do
+                XORRISO_MAPS+=(-map "$ISO_GRUB_FILE" "$path")
+              done
+              xorriso -indev "$ISO_OUT" \
+                -outdev "${ISO_OUT}.tmp" \
+                -boot_image any replay \
+                "${XORRISO_MAPS[@]}" \
+                -end
+              mv "${ISO_OUT}.tmp" "$ISO_OUT"
+              echo "grub.cfg patched successfully at ${#GRUB_CFG_PATHS[@]} location(s)"
+            fi
           fi
 
           implantisomd5 --force "$ISO_OUT"
@@ -665,16 +696,47 @@ jobs:
           # file in a bootable ISO without breaking boot.
           if [ -n "$ISO_GRUB_FILE" ] && [ -f "$ISO_GRUB_FILE" ]; then
             echo "Patching grub.cfg in ISO with $ISO_GRUB_FILE"
+            # Fedora ISOs ship TWO grub.cfg files that we must BOTH
+            # replace to stop the "Install Fedora 43" menu from leaking
+            # through on one boot path while the xiboplayer menu shows
+            # on another:
+            #
+            #   /EFI/BOOT/grub.cfg      — Secure Boot UEFI path (shim
+            #                              → grubx64.efi reads this)
+            #   /boot/grub2/grub.cfg    — BIOS eltorito + some UEFI
+            #                              paths read this one
+            #
+            # Previously we only patched /EFI/BOOT/grub.cfg, so BIOS
+            # boots + certain UEFI setups saw the unmodified Fedora
+            # menu. Discover any additional grub.cfg paths at runtime
+            # and map them ALL in a single xorriso session (cheaper
+            # than running xorriso per file).
+            #
             # -outdev must be a FRESH file (xorriso refuses to write
             # to a non-empty file that differs from -indev). Write to
             # .tmp then mv back.
-            xorriso -indev "$ISO_OUT" \
-              -outdev "${ISO_OUT}.tmp" \
-              -boot_image any replay \
-              -map "$ISO_GRUB_FILE" /EFI/BOOT/grub.cfg \
-              -end
-            mv "${ISO_OUT}.tmp" "$ISO_OUT"
-            echo "grub.cfg patched successfully"
+            mapfile -t GRUB_CFG_PATHS < <(
+              xorriso -indev "$ISO_OUT" \
+                -find / -name 'grub.cfg' 2>/dev/null \
+                | awk "/^'\\/.*grub\\.cfg'\$/ { gsub(/'/,\"\"); print }"
+            )
+            if [ "${#GRUB_CFG_PATHS[@]}" -eq 0 ]; then
+              echo "WARNING: no grub.cfg paths found in $ISO_OUT — skipping patch"
+            else
+              echo "Found ${#GRUB_CFG_PATHS[@]} grub.cfg path(s):"
+              printf '  - %s\n' "${GRUB_CFG_PATHS[@]}"
+              XORRISO_MAPS=()
+              for path in "${GRUB_CFG_PATHS[@]}"; do
+                XORRISO_MAPS+=(-map "$ISO_GRUB_FILE" "$path")
+              done
+              xorriso -indev "$ISO_OUT" \
+                -outdev "${ISO_OUT}.tmp" \
+                -boot_image any replay \
+                "${XORRISO_MAPS[@]}" \
+                -end
+              mv "${ISO_OUT}.tmp" "$ISO_OUT"
+              echo "grub.cfg patched successfully at ${#GRUB_CFG_PATHS[@]} location(s)"
+            fi
           fi
 
           # Embed checksum so "Verify media" (rd.live.check) works


### PR DESCRIPTION
## Why

Fedora ISOs ship grub.cfg at **two** locations:

- `/EFI/BOOT/grub.cfg` — Secure Boot UEFI (shim → grubx64.efi)
- `/boot/grub2/grub.cfg` — BIOS eltorito + some non-secure UEFI paths

The previous xorriso post-patch (from #28) only targeted the EFI path, so BIOS boots and certain UEFI configurations saw the unmodified Fedora "Install Fedora 43" menu while Secure Boot UEFI showed the xiboplayer-branded menu.

Confirmed today by extracting both files from the v0.4.36 test ISO:

\`\`\`
=== /EFI/BOOT/grub.cfg ===
# xiboplayer kiosk — UEFI boot menu    ✅ our menu
=== /boot/grub2/grub.cfg ===
menuentry 'Install Fedora 43' ...      ❌ Fedora default
\`\`\`

## What

Enumerate grub.cfg paths with \`xorriso -find\` at runtime and \`-map\` each of them in a single xorriso session. Covers any future Fedora layout changes too — if Fedora 44 adds a third grub.cfg, this code patches it automatically.

Both netinstall and offline-iso jobs updated. Logs now read:
\`\`\`
Found 2 grub.cfg path(s):
  - /EFI/BOOT/grub.cfg
  - /boot/grub2/grub.cfg
grub.cfg patched successfully at 2 location(s)
\`\`\`

## Test plan

- [ ] Bump SHA pin in xiboplayer-kiosk test-image.yml + image.yml to this merge commit
- [ ] Trigger test-image.yml against xiboplayer-kiosk main
- [ ] Boot resulting ISO on BIOS → verify xiboplayer menu (was Fedora menu)
- [ ] Boot resulting ISO on Secure Boot UEFI → still xiboplayer menu