### PR TITLE
fix(build-iso): restore xorriso post-patch with -boot_image any replay

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -531,6 +531,26 @@ jobs:
             /tmp/fedora-netinst.iso \
             "$ISO_OUT"
 
+          # Post-patch grub.cfg — our --add overlay is OVERWRITTEN by
+          # mkksiso's internal EditGrub2/RebuildEFIBoot step, so we must
+          # re-apply afterwards. `-boot_image any replay` inherits every
+          # El Torito catalog entry, MBR/GPT table and appended partition
+          # (incl. efiboot.img) from the input ISO. Only the two grub.cfg
+          # files are substituted. This avoids the #146 regression our
+          # previous plain `xorriso -map` pass caused by dropping the
+          # `-append_partition 2 efiboot.img` metadata.
+          if [ -n "$ISO_GRUB_FILE" ] && [ -f "$ISO_GRUB_FILE" ]; then
+            mv "$ISO_OUT" "${ISO_OUT}.pre-grub"
+            xorriso \
+              -indev "${ISO_OUT}.pre-grub" \
+              -outdev "$ISO_OUT" \
+              -boot_image any replay \
+              -map "$ISO_GRUB_FILE" /EFI/BOOT/grub.cfg \
+              -map "$ISO_GRUB_FILE" /boot/grub2/grub.cfg \
+              --
+            rm -f "${ISO_OUT}.pre-grub"
+          fi
+
           implantisomd5 --force "$ISO_OUT"
           ls -lah "$ISO_OUT"
 
@@ -673,8 +693,30 @@ jobs:
             /tmp/fedora-netinst.iso \
             "$ISO_OUT"
 
+          # Post-patch grub.cfg — our --add overlay is OVERWRITTEN by
+          # mkksiso's internal EditGrub2/RebuildEFIBoot step, so we must
+          # re-apply afterwards. `-boot_image any replay` inherits every
+          # El Torito catalog entry, MBR/GPT table and appended partition
+          # (incl. efiboot.img) from the input ISO. Only the two grub.cfg
+          # files are substituted. This avoids the #146 regression our
+          # previous plain `xorriso -map` pass caused by dropping the
+          # `-append_partition 2 efiboot.img` metadata.
+          if [ -n "$ISO_GRUB_FILE" ] && [ -f "$ISO_GRUB_FILE" ]; then
+            mv "$ISO_OUT" "${ISO_OUT}.pre-grub"
+            xorriso \
+              -indev "${ISO_OUT}.pre-grub" \
+              -outdev "$ISO_OUT" \
+              -boot_image any replay \
+              -map "$ISO_GRUB_FILE" /EFI/BOOT/grub.cfg \
+              -map "$ISO_GRUB_FILE" /boot/grub2/grub.cfg \
+              --
+            rm -f "${ISO_OUT}.pre-grub"
+          fi
+
           # Embed checksum so "Verify media" (rd.live.check) works
           # on the modified ISO. --force overwrites Fedora's stale checksum.
+          # Runs AFTER the xorriso post-patch so the stored checksum
+          # reflects the final file layout (with our grub.cfg).
           implantisomd5 --force "$ISO_OUT"
 
           ls -lah "$ISO_OUT"


### PR DESCRIPTION
## Summary

- Re-adds xorriso post-patch after mkksiso in both netinstall and offline/everything jobs
- Uses `-boot_image any replay` to preserve every boot structure (El Torito catalog, MBR/GPT, appended partitions including `efiboot.img`, isolinux) from mkksiso's output
- Only substitutes `/EFI/BOOT/grub.cfg` and `/boot/grub2/grub.cfg` via `-map`
- Moves `implantisomd5` to run after the post-patch so the checksum reflects the final layout

## Why

PR #32 dropped the xorriso post-patch and relied on `mkksiso --add` to overlay grub.cfg. Verification in QEMU against bc8f60b458ac (kiosk main) showed the published `/EFI/BOOT/grub.cfg` contains Fedora's stock menuentries:

\`\`\`
menuentry 'Install Fedora 43' --class fedora ...
menuentry 'Test this media & install Fedora 43' --class fedora ...
submenu 'Troubleshooting -->' { ... }
\`\`\`

Our debug flags and `inst.ks=` reference WERE injected (so mkksiso processed the file), but the menuentry titles reverted to stock — proving mkksiso's internal `EditGrub2`/`RebuildEFIBoot` step runs AFTER `--add` and overwrites the overlay. mkksiso has no `--grub-cfg FILE` equivalent; `-R` substitutions can't introduce new menuentries with different `xibo.profile=` kernel args.

## Why the previous xorriso approach broke

The pre-#32 xorriso pass used plain `-map` without `-boot_image any replay`, which caused xorriso to reassemble boot structures from scratch. That reassembly dropped the `-append_partition 2 efiboot.img` GPT-partition registration mkksiso set up, breaking UEFI boot on some VM firmwares (xibo-players/xiboplayer-kiosk#146).

`-boot_image any replay` fixes this: xorriso inherits the input's boot structures verbatim instead of rebuilding them.

## Test plan

- [ ] Downstream test build (test-image.yml on kiosk/main) produces a bootable ISO
- [ ] QEMU UEFI boot shows xiboplayer-branded GRUB menu (no "Install Fedora 43")
- [ ] QEMU UEFI install proceeds through anaconda → reboot → kiosk session
- [ ] QEMU BIOS (SeaBIOS) round — Stage H of kiosk test plan — still boots and installs
- [ ] Bug #146 marked verified in docs/TEST_PLAN_0.5.x.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)