### PR TITLE
refactor(gpg): accept raw ASCII armor only, drop base64 layer

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -260,9 +260,9 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.DEB_GPG_KEY }}
         run: |
-          # Import GPG key to export public part
-          # Secret must be base64-encoded: base64 -w0 < key.asc | gh secret set ...
-          echo "$GPG_KEY" | base64 -d | gpg --batch --import
+          # Import GPG key to export public part. Secret stores raw
+          # ASCII armor — pipe directly, no base64 layer.
+          printf '%s\n' "$GPG_KEY" | gpg --batch --import
 
           # Export public key for repository consumers
           # (APT repo signing is done in update-repos.yml via Release.gpg/InRelease)

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -305,9 +305,10 @@ jobs:
         run: |
           dnf install -y rpm-sign gnupg2 pinentry
 
-          # Import GPG private key
-          # Secret must be base64-encoded: base64 -w0 < key.asc | gh secret set ...
-          echo "$GPG_KEY" | base64 -d | gpg --batch --import
+          # Import GPG private key. Secret stores raw ASCII armor
+          # (output of `gpg --armor --export-secret-keys`) — pipe directly
+          # to gpg, no base64 layer. See #xxx / verify-signing-keys.yml.
+          printf '%s\n' "$GPG_KEY" | gpg --batch --import
 
           # Create a custom pinentry that serves the passphrase non-interactively.
           # RPM 6.0 (Fedora 43) ignores %__gpg_sign_cmd macro overrides and

--- a/.github/workflows/verify-signing-keys.yml
+++ b/.github/workflows/verify-signing-keys.yml
@@ -27,160 +27,84 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Import + verify fingerprint + test-sign
-        # shell: bash {0} (not bash -eo pipefail) so diagnostic commands
-        # keep running past failed pipelines and we can see actual errors.
-        shell: bash {0}
         env:
           GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ secrets.RPM_GPG_KEY_ID }}
         run: |
-          # Without -e: failed command substitutions don't abort the script,
-          # so we can capture stderr + exit codes and report them.
+          set -euo pipefail
 
           if [ -z "$GPG_KEY" ]; then
             echo "::error::RPM_GPG_KEY secret is empty or not accessible"
             exit 1
           fi
 
-          echo "RPM_GPG_KEY length: ${#GPG_KEY}"
-          echo "RPM_GPG_KEY first 6 chars: '$(printf '%s' "$GPG_KEY" | head -c 6)'"
-          echo "RPM_GPG_KEY last 6 chars:  '$(printf '%s' "$GPG_KEY" | tail -c 6)'"
-          echo "  (base64 of '-----BEGIN' starts 'LS0tLS1CRUdJTi')"
-          echo "  (raw armor starts '-----BEGIN PGP')"
-
           export GNUPGHOME=$(mktemp -d)
           chmod 700 "$GNUPGHOME"
 
-          # Try raw ASCII armor first — the native gpg export format.
-          # Capture stderr so we can see the actual gpg parse error.
-          echo "--- attempting import as RAW ASCII armor ---"
-          RAW_STDERR=$(printf '%s\n' "$GPG_KEY" | gpg --batch --import 2>&1)
-          RAW_RC=$?
-          echo "$RAW_STDERR"
-          echo "raw-import exit code: $RAW_RC"
-
-          # If raw failed, try base64 decode first
-          if [ "$RAW_RC" -ne 0 ]; then
-            echo "--- attempting import as BASE64 of armor ---"
-            B64_STDERR=$(printf '%s\n' "$GPG_KEY" | base64 -d 2>&1 | gpg --batch --import 2>&1)
-            B64_RC=$?
-            echo "$B64_STDERR"
-            echo "base64-import exit code: $B64_RC"
-            if [ "$B64_RC" -ne 0 ]; then
-              echo "::error::RPM_GPG_KEY is neither valid raw ASCII armor nor valid base64 of armor"
-              exit 1
-            fi
-            echo "::notice::Imported as base64-wrapped armor"
-          else
-            echo "::notice::Imported as raw ASCII armor (base64 layer was unnecessary — refactor PR will drop it)"
-          fi
-
-          echo "::group::Imported secret keys"
-          gpg --list-secret-keys --with-colons
-          echo "::endgroup::"
+          # Import raw ASCII armor — the only supported format.
+          printf '%s\n' "$GPG_KEY" | gpg --batch --import
 
           IMPORTED_FP=$(gpg --list-secret-keys --with-colons \
             | awk -F: '/^fpr:/ {print $10; exit}')
 
-          echo "Imported primary fingerprint: ${IMPORTED_FP:-<none found>}"
-          echo "Expected primary fingerprint: $EXPECTED_FP"
-
           if [ -z "$IMPORTED_FP" ]; then
-            echo "::error::No secret key imported — check the secret holds an ASCII-armored PRIVATE key"
-            echo "::error::(a PUBLIC key export is shorter; gpg --armor --export-SECRET-keys is required)"
+            echo "::error::No secret key imported — secret must hold an ASCII-armored PRIVATE key"
             exit 1
           fi
-
           if [ "$IMPORTED_FP" != "$EXPECTED_FP" ]; then
-            echo "::error::RPM_GPG_KEY fingerprint MISMATCH"
+            echo "::error::RPM_GPG_KEY fingerprint $IMPORTED_FP does not match expected $EXPECTED_FP"
             exit 1
           fi
-          echo "::notice::RPM_GPG_KEY fingerprint matches the org key"
 
-          # RPM_GPG_KEY_ID must reference the same key
-          if [ -n "$GPG_KEY_ID" ]; then
-            if ! printf '%s\n' "$IMPORTED_FP" | grep -qi "${GPG_KEY_ID#0x}$"; then
-              echo "::error::RPM_GPG_KEY_ID ($GPG_KEY_ID) does not match imported fingerprint suffix"
-              exit 1
-            fi
-            echo "::notice::RPM_GPG_KEY_ID references the same key as RPM_GPG_KEY"
-          else
-            echo "::warning::RPM_GPG_KEY_ID secret is not set (ok — will derive from imported key in refactor)"
+          if [ -n "${GPG_KEY_ID:-}" ] && ! printf '%s' "$IMPORTED_FP" | grep -qi "${GPG_KEY_ID#0x}$"; then
+            echo "::error::RPM_GPG_KEY_ID secret does not reference the imported key"
+            exit 1
           fi
 
-          # Test passphrase with a throwaway signature — catches "wrong passphrase"
-          # before a real build chokes mid-transaction.
-          echo "test payload" > /tmp/verify.txt
-          echo "$GPG_PASSPHRASE" \
-            | gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
-                  --detach-sign --output /tmp/verify.sig /tmp/verify.txt
-          gpg --verify /tmp/verify.sig /tmp/verify.txt
-          echo "::notice::RPM_GPG_PASSPHRASE unlocks the key"
+          # Test passphrase by signing a throwaway payload.
+          echo "test" | gpg --batch --pinentry-mode loopback --passphrase-fd 3 \
+            --local-user "$EXPECTED_FP" --detach-sign --output /dev/null 3< <(printf '%s' "$GPG_PASSPHRASE")
+
+          echo "::notice::RPM_GPG_KEY imported + matches fingerprint + passphrase unlocks"
 
   verify-deb:
     name: DEB signing key
     runs-on: ubuntu-latest
     steps:
       - name: Import + verify fingerprint + test-sign
-        shell: bash {0}
         env:
           GPG_KEY: ${{ secrets.DEB_GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.DEB_GPG_PASSPHRASE }}
         run: |
+          set -euo pipefail
+
           if [ -z "$GPG_KEY" ]; then
             echo "::error::DEB_GPG_KEY secret is empty or not accessible"
             exit 1
           fi
 
-          echo "DEB_GPG_KEY length: ${#GPG_KEY}"
-          echo "DEB_GPG_KEY first 6 chars: '$(printf '%s' "$GPG_KEY" | head -c 6)'"
-          echo "DEB_GPG_KEY last 6 chars:  '$(printf '%s' "$GPG_KEY" | tail -c 6)'"
-
           export GNUPGHOME=$(mktemp -d)
           chmod 700 "$GNUPGHOME"
 
-          echo "--- attempting import as RAW ASCII armor ---"
-          RAW_STDERR=$(printf '%s\n' "$GPG_KEY" | gpg --batch --import 2>&1)
-          RAW_RC=$?
-          echo "$RAW_STDERR"
-          echo "raw-import exit code: $RAW_RC"
-
-          if [ "$RAW_RC" -ne 0 ]; then
-            echo "--- attempting import as BASE64 of armor ---"
-            B64_STDERR=$(printf '%s\n' "$GPG_KEY" | base64 -d 2>&1 | gpg --batch --import 2>&1)
-            B64_RC=$?
-            echo "$B64_STDERR"
-            echo "base64-import exit code: $B64_RC"
-            if [ "$B64_RC" -ne 0 ]; then
-              echo "::error::DEB_GPG_KEY is neither valid raw ASCII armor nor valid base64 of armor"
-              exit 1
-            fi
-            echo "::notice::Imported as base64-wrapped armor"
-          else
-            echo "::notice::Imported as raw ASCII armor"
-          fi
-
-          echo "::group::Imported secret keys"
-          gpg --list-secret-keys --with-colons
-          echo "::endgroup::"
+          printf '%s\n' "$GPG_KEY" | gpg --batch --import
 
           IMPORTED_FP=$(gpg --list-secret-keys --with-colons \
             | awk -F: '/^fpr:/ {print $10; exit}')
 
-          echo "Imported primary fingerprint: ${IMPORTED_FP:-<none found>}"
-          echo "Expected primary fingerprint: $EXPECTED_FP"
-
           if [ -z "$IMPORTED_FP" ]; then
-            echo "::error::No secret key imported — check the secret holds an ASCII-armored PRIVATE key (not public)"
+            echo "::error::No secret key imported — secret must hold an ASCII-armored PRIVATE key"
+            exit 1
+          fi
+          if [ "$IMPORTED_FP" != "$EXPECTED_FP" ]; then
+            echo "::error::DEB_GPG_KEY fingerprint $IMPORTED_FP does not match expected $EXPECTED_FP"
             exit 1
           fi
 
-          if [ "$IMPORTED_FP" != "$EXPECTED_FP" ]; then
-            echo "::error::DEB_GPG_KEY fingerprint MISMATCH"
-            exit 1
-          fi
-          echo "::notice::DEB_GPG_KEY fingerprint matches the org key"
+          echo "test" | gpg --batch --pinentry-mode loopback --passphrase-fd 3 \
+            --local-user "$EXPECTED_FP" --clearsign --output /dev/null 3< <(printf '%s' "$GPG_PASSPHRASE")
+
+          echo "::notice::DEB_GPG_KEY imported + matches fingerprint + passphrase unlocks"
 
           echo "test payload" > /tmp/verify.txt
           echo "$GPG_PASSPHRASE" \


### PR DESCRIPTION
Secrets now store raw armor (native `gpg --armor --export-secret-keys` output). The base64 layer was historical cargo-cult and added nothing — GitHub Actions env vars handle multi-line values fine.

Closes the signing-key mismatch that produced mis-signed RPMs/DEBs since 2026-04-14. Verified by run 24441212661 that current secrets are already raw-armored + match expected org fingerprint.

Workflows:
- build-rpm.yml: `printf '%s\n' "$GPG_KEY" | gpg --import`
- build-deb.yml: same
- verify-signing-keys.yml: simplified to single-path import

Companion PR in xiboplayer-ghpages applies the same fix to update-repos.yml.