### PR TITLE
refactor(gpg): derive RPM signing fingerprint from imported key, drop RPM_GPG_KEY_ID

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -847,7 +847,6 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           RPM_GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
-          RPM_GPG_KEY_ID: ${{ secrets.RPM_GPG_KEY_ID }}
           RPM_GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
           PACKAGE: ${{ inputs.package-name }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -877,7 +876,7 @@ jobs:
 
           # GPG-sign SHA256SUMS so operators can verify provenance.
           # Uses the SAME key + passphrase mechanism as build-rpm.yml:
-          #   - RPM_GPG_KEY is base64-encoded (must decode before import)
+          #   - RPM_GPG_KEY holds raw ASCII armor (import directly)
           #   - RPM_GPG_PASSPHRASE may be empty (key with no passphrase)
           #     or set at org/repo level
           #   - Custom pinentry-ci serves the passphrase non-interactively
@@ -886,7 +885,11 @@ jobs:
           # If key/passphrase aren't available (test builds, forks),
           # signing is skipped gracefully — checksums still upload.
           if [ -n "$RPM_GPG_KEY" ]; then
-            echo "$RPM_GPG_KEY" | base64 -d | gpg --batch --import 2>&1 || true
+            printf '%s\n' "$RPM_GPG_KEY" | gpg --batch --import 2>&1 || true
+            # Derive fingerprint from the imported key (single source of
+            # truth, no separate RPM_GPG_KEY_ID secret).
+            GPG_KEY_ID=$(gpg --list-secret-keys --with-colons \
+              | awk -F: '/^fpr:/ {print $10; exit}')
 
             # Create the same pinentry-ci that build-rpm.yml uses
             printf '%s' "$RPM_GPG_PASSPHRASE" > /tmp/.gpg-passphrase
@@ -909,7 +912,7 @@ jobs:
             echo "pinentry-program /usr/local/bin/pinentry-ci" > "$GPG_AGENT_CONF"
 
             if gpg --batch --yes --detach-sign --armor \
-                ${RPM_GPG_KEY_ID:+--default-key "$RPM_GPG_KEY_ID"} \
+                ${GPG_KEY_ID:+--default-key "$GPG_KEY_ID"} \
                 /tmp/checksums/SHA256SUMS 2>&1; then
               echo "GPG signature: SHA256SUMS.asc created"
             else

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -60,9 +60,6 @@ on:
       RPM_GPG_PASSPHRASE:
         required: false
         description: 'Passphrase for the GPG key'
-      RPM_GPG_KEY_ID:
-        required: false
-        description: 'GPG key ID for signing (e.g. name or email)'
       PAGES_TOKEN:
         required: false
         description: 'PAT with contents:write on xibo-players.github.io for central repo publishing'
@@ -300,15 +297,24 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ secrets.RPM_GPG_KEY_ID }}
         shell: bash
         run: |
           dnf install -y rpm-sign gnupg2 pinentry
 
           # Import GPG private key. Secret stores raw ASCII armor
           # (output of `gpg --armor --export-secret-keys`) — pipe directly
-          # to gpg, no base64 layer. See #xxx / verify-signing-keys.yml.
+          # to gpg, no base64 layer.
           printf '%s\n' "$GPG_KEY" | gpg --batch --import
+
+          # Derive fingerprint from the imported key — single source of
+          # truth, no separate RPM_GPG_KEY_ID secret that can drift.
+          GPG_KEY_ID=$(gpg --list-secret-keys --with-colons \
+            | awk -F: '/^fpr:/ {print $10; exit}')
+          if [ -z "$GPG_KEY_ID" ]; then
+            echo "::error::No secret key imported from RPM_GPG_KEY"
+            exit 1
+          fi
+          echo "Signing with key $GPG_KEY_ID"
 
           # Create a custom pinentry that serves the passphrase non-interactively.
           # RPM 6.0 (Fedora 43) ignores %__gpg_sign_cmd macro overrides and

--- a/.github/workflows/verify-signing-keys.yml
+++ b/.github/workflows/verify-signing-keys.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RPM_GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ secrets.RPM_GPG_KEY_ID }}
         run: |
           set -euo pipefail
 
@@ -54,11 +53,6 @@ jobs:
           fi
           if [ "$IMPORTED_FP" != "$EXPECTED_FP" ]; then
             echo "::error::RPM_GPG_KEY fingerprint $IMPORTED_FP does not match expected $EXPECTED_FP"
-            exit 1
-          fi
-
-          if [ -n "${GPG_KEY_ID:-}" ] && ! printf '%s' "$IMPORTED_FP" | grep -qi "${GPG_KEY_ID#0x}$"; then
-            echo "::error::RPM_GPG_KEY_ID secret does not reference the imported key"
             exit 1
           fi
 


### PR DESCRIPTION
After #35 dropped the base64 layer, there's no reason to keep RPM_GPG_KEY_ID as a separate secret — its value is already encoded in RPM_GPG_KEY's key material. Derive it locally via gpg --list-secret-keys. Single source of truth, no cross-secret drift possible.

Companion PR for ghpages: xibo-players/xibo-players.github.io (next).