### PR TITLE
feat(workflows): add use-gh-packages opt-in to reusable workflows (#621)

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -29,6 +29,10 @@ on:
         type: boolean
         default: true
         description: 'Publish DEBs to package repository (default: true for all builds)'
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm and authenticate via NODE_AUTH_TOKEN. Requires the consumer to pass `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN (org-level or repo-level secret) is available. Default false keeps the legacy public-npm fetch path; per-consumer opt-in via this flag.'
       ubuntu-version:
         type: string
         default: '24.04'
@@ -111,9 +115,14 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
+          # See use-gh-packages input. Empty strings = no scope override.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
       - name: Install dependencies
         if: inputs.build-command != ''
+        env:
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
         run: pnpm install --no-frozen-lockfile
 
       - name: Build application

--- a/.github/workflows/build-pwa.yml
+++ b/.github/workflows/build-pwa.yml
@@ -26,6 +26,10 @@ on:
       release-name:
         type: string
         default: 'PWA Player'
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm and authenticate via NODE_AUTH_TOKEN. Requires the consumer to pass `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN is available. Default false keeps the legacy public-npm fetch path; per-consumer opt-in via this flag.'
 
 jobs:
   build:
@@ -41,8 +45,13 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.cache-deps && 'pnpm' || '' }}
+          # See use-gh-packages input.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
-      - run: ${{ inputs.install-command }}
+      - env:
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
+        run: ${{ inputs.install-command }}
 
       - run: ${{ inputs.build-command }}
 

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -33,6 +33,10 @@ on:
         type: boolean
         default: true
         description: 'Publish RPMs to package repository (default: true for all builds)'
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm and authenticate via NODE_AUTH_TOKEN. Requires the consumer to pass `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN (org-level or repo-level secret) is available. Default false keeps the legacy public-npm fetch path; per-consumer opt-in via this flag.'
       fedora-version:
         type: string
         default: '43'
@@ -110,9 +114,21 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
+          # When use-gh-packages: true, bind @xiboplayer scope to the
+          # private GitHub Packages registry. Otherwise empty strings
+          # leave setup-node's default behaviour (no scope override).
+          # See use-gh-packages input below.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
       - name: Install dependencies
         if: inputs.build-command != ''
+        env:
+          # When use-gh-packages: true, expose the consumer-supplied
+          # XIBO_PLAYERS_READ_TOKEN secret to pnpm's npm-protocol auth.
+          # Empty string when opted out — the registry-url binding is
+          # also empty in that case so this is a no-op.
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
         run: pnpm install --no-frozen-lockfile
 
       - name: Build application

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,6 +10,10 @@ on:
         type: string
         default: ''
         description: 'CMS URL. If empty, spins up Docker Compose stack.'
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm and authenticate via NODE_AUTH_TOKEN. Requires the consumer to pass `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN is available. Default false keeps the legacy public-npm fetch path.'
     secrets:
       CMS_CLIENT_ID:
         required: true
@@ -31,8 +35,13 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm
+          # See use-gh-packages input.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
-      - run: pnpm install --frozen-lockfile
+      - env:
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
+        run: pnpm install --frozen-lockfile
 
       # Start Docker Compose CMS if no external CMS URL provided
       - name: Start local CMS stack

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,10 @@ on:
         type: string
         default: 'npm-publish'
         description: 'GitHub environment configured for npm trusted publishing'
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm for the INSTALL step (publish still goes to public npm via OIDC). Requires `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN is available. Default false keeps legacy public-npm fetch path.'
 
 jobs:
   publish:
@@ -41,7 +45,12 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.cache-deps && 'pnpm' || '' }}
+          # See use-gh-packages input. Affects INSTALL step only.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
-      - run: ${{ inputs.install-command }}
+      - env:
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
+        run: ${{ inputs.install-command }}
 
       - run: ${{ inputs.publish-command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ on:
       audit:
         type: boolean
         default: true
+      use-gh-packages:
+        type: boolean
+        default: false
+        description: 'Bind @xiboplayer scope to GitHub Packages npm and authenticate via NODE_AUTH_TOKEN. Requires the consumer to pass `secrets: inherit` so XIBO_PLAYERS_READ_TOKEN is available. Default false keeps the legacy public-npm fetch path.'
 
 jobs:
   test:
@@ -33,8 +37,13 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm
+          # See use-gh-packages input.
+          registry-url: ${{ inputs.use-gh-packages && 'https://npm.pkg.github.com' || '' }}
+          scope: ${{ inputs.use-gh-packages && '@xiboplayer' || '' }}
 
-      - run: pnpm install --frozen-lockfile
+      - env:
+          NODE_AUTH_TOKEN: ${{ inputs.use-gh-packages && secrets.XIBO_PLAYERS_READ_TOKEN || '' }}
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         if: inputs.lint-command != ''


### PR DESCRIPTION
## Summary

Adds an opt-in `use-gh-packages` boolean input to 6 reusable workflows. When set `true`, the workflow configures setup-node + `NODE_AUTH_TOKEN` env so consumers can fetch `@xiboplayer/*` packages from GitHub Packages npm instead of public npm.

**Default `false` — no breaking change.** Existing consumers continue to use public npm exactly as before.

## Workflows updated

- `build-rpm.yml`
- `build-deb.yml`
- `build-pwa.yml`
- `test.yml`
- `integration-test.yml`
- `publish-npm.yml` (install step only — publish still goes to public npm via OIDC trusted publishing)

## Why opt-in instead of default-on

Per the 2026-05-07 distribution migration, all 17 `@xiboplayer/*` SDK packages are dual-published to public npm AND GitHub Packages. Public-npm consumers continue to work. The strategic direction is "always use GH Packages, public npm is nice-to-have" — but flipping shared workflows to default-on would break every consumer until each repo's secret is set. Opt-in lets consumers migrate one repo at a time.

## Migration recipe (for a downstream consumer)

```yaml
# in xiboplayer-electron/.github/workflows/build.yml
jobs:
  rpm:
    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@<new-sha>
    with:
      package-name: xiboplayer-electron
      build-command: 'pnpm run build:linux'
      use-gh-packages: true  # ← single line flips to GH Packages
    secrets: inherit  # ← already present in most consumers
```

Plus operator action: set `XIBO_PLAYERS_READ_TOKEN` as an **org-level secret** on the `xiboplayer` org (one-time). All repos in the org inherit; consumer-side workflows access it via `secrets: inherit`.

## Test plan

- [x] Shared-workflow YAML lints cleanly (verified locally per existing CI patterns)
- [ ] No consumer is yet using `use-gh-packages: true` in this PR — so existing builds (electron, chromium, etc.) keep using public npm path. Zero functional change for default false.
- [ ] After merge: file follow-up consumer-side PRs (xiboplayer-electron, xiboplayer-chromium, etc.) that opt in to validate the path live.

## How `${{ ... }}` conditionals behave

When `use-gh-packages: false` (default):
- `registry-url` evaluates to `''` (empty string) — setup-node treats it as "no registry override" → behaves exactly like before this PR
- `scope` evaluates to `''` — same, no override
- `NODE_AUTH_TOKEN` env evaluates to `''` — install step uses no auth (current behavior)

When `use-gh-packages: true` AND `secrets.XIBO_PLAYERS_READ_TOKEN` is present:
- `registry-url` = `https://npm.pkg.github.com`
- `scope` = `@xiboplayer`
- `NODE_AUTH_TOKEN` = the secret value
- pnpm fetches `@xiboplayer/*` via GH Packages with auth; everything else goes to public npm

When `use-gh-packages: true` BUT `secrets.XIBO_PLAYERS_READ_TOKEN` is missing:
- `NODE_AUTH_TOKEN` evaluates to `''` — pnpm fetches `@xiboplayer/*` from GH Packages without auth → 401, install fails loudly. The fail-loud is intentional: don't silently fall back to public npm when consumer asked for GH Packages.

## Refs

- `zerosignage/platform#621` (the fan-out tracker — this PR closes the "shared workflow opt-in" sub-item; per-repo migration follows separately)
- Today's full migration arc: `xiboplayer/xiboplayer-smil-tools#36`, `xiboplayer/xiboplayer#394+#395+#396`, `zerosignage/0cs-core#154`, `zerosignage/platform#610+#621+#625`