### PR TITLE
chore(workflows): point dispatch URLs at renamed gh-pages repo

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -368,6 +368,6 @@ jobs:
           curl -sf -X POST \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/xibo-players/xibo-players.github.io/dispatches" \
+            "https://api.github.com/repos/xiboplayer/xiboplayer.github.io/dispatches" \
             -d '{"event_type": "update-repos", "client_payload": {"package": "${{ inputs.package-name }}", "repo": "${{ github.repository }}"}}'
           echo "Triggered update-repos for ${{ inputs.package-name }}"

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -491,6 +491,6 @@ jobs:
           curl -sf -X POST \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/xibo-players/xibo-players.github.io/dispatches" \
+            "https://api.github.com/repos/xiboplayer/xiboplayer.github.io/dispatches" \
             -d '{"event_type": "update-repos", "client_payload": {"package": "${{ inputs.package-name }}", "repo": "${{ github.repository }}"}}'
           echo "Triggered update-repos for ${{ inputs.package-name }}"


### PR DESCRIPTION
## Summary

After two cosmetic renames landed:
1. GH org `xibo-players` → `xiboplayer`
2. Pages repo `xibo-players.github.io` → `xiboplayer.github.io` (xiboplayer/xiboplayer.github.io#17, merged 2026-05-08)

The two reusable workflows that fan out to a `repository_dispatch` POST need the new literal path. GitHub honors 301 redirects on fetches but POSTs to `api.github.com/repos/<owner>/<repo>/dispatches` are not reliably redirected — so updating the URL string is the durable fix rather than relying on the redirect chain.

The `xiboplayer/xiboplayer.github.io/.github/workflows/build-release-pkg.yml` self-dispatch was updated in the same merge that renamed the repo.

## Test plan

- [ ] Next deb build (any consumer) verifies `update-repos` job triggers in xiboplayer.github.io
- [ ] Next RPM build (any consumer) verifies same

🤖 Generated with [Claude Code](https://claude.com/claude-code)