### PR TITLE
chore: rename xibo-players GH org references → xiboplayer

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -62,7 +62,7 @@ on:
         description: 'Passphrase for the GPG key'
       PAGES_TOKEN:
         required: false
-        description: 'PAT with contents:write on xibo-players.github.io for central repo publishing'
+        description: 'PAT with contents:write on xiboplayer.github.io for central repo publishing'
       R2_ACCESS_KEY_ID:
         required: false
       R2_SECRET_ACCESS_KEY:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -66,7 +66,7 @@ on:
         description: 'Passphrase for the GPG key'
       PAGES_TOKEN:
         required: false
-        description: 'PAT with contents:write on xibo-players.github.io for central repo publishing'
+        description: 'PAT with contents:write on xiboplayer.github.io for central repo publishing'
       R2_ACCESS_KEY_ID:
         required: false
       R2_SECRET_ACCESS_KEY:

--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -9,7 +9,7 @@ name: Cleanup old releases (reusable)
 # Usage:
 #   jobs:
 #     cleanup:
-#       uses: xibo-players/.github/.github/workflows/cleanup-releases.yml@main
+#       uses: xiboplayer/.github/.github/workflows/cleanup-releases.yml@main
 #       with:
 #         keep-versioned: 3
 #         keep-dated: 7

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -100,7 +100,7 @@ jobs:
 
               <div class="card">
                   <h3>📚 Documentation</h3>
-                  <p><a href="https://github.com/xibo-players/.github">GitHub Repository</a></p>
+                  <p><a href="https://github.com/xiboplayer/.github">GitHub Repository</a></p>
               </div>
           </body>
           </html>

--- a/CUSTOM-DOMAIN-SETUP.md
+++ b/CUSTOM-DOMAIN-SETUP.md
@@ -20,7 +20,7 @@ This guide explains how the custom domain `dl.xiboplayer.org` was configured. Ke
 
 ## How It Was Configured
 
-Instead of using the default GitHub Pages URL (`xibo-players.github.io/.github`), we configured the custom domain `dl.xiboplayer.org` for cleaner, more professional URLs.
+Instead of using the default GitHub Pages URL (`xiboplayer.github.io/.github`), we configured the custom domain `dl.xiboplayer.org` for cleaner, more professional URLs.
 
 **Result (Now Active):**
 - Repository URLs: `https://dl.xiboplayer.org/rpm/fedora/43/x86_64/`
@@ -41,7 +41,7 @@ A CNAME record was added in the DNS provider's control panel:
 
 | Type  | Name | Value                          | TTL  |
 |-------|------|--------------------------------|------|
-| CNAME | dnf  | xibo-players.github.io.        | 3600 |
+| CNAME | dnf  | xiboplayer.github.io.        | 3600 |
 
 **Important:** Note the trailing dot (`.`) after `github.io` - some DNS providers require it.
 
@@ -54,7 +54,7 @@ A CNAME record was added in the DNS provider's control panel:
 4. Click "Add record"
 5. Type: `CNAME`
 6. Name: `dnf`
-7. Target: `xibo-players.github.io`
+7. Target: `xiboplayer.github.io`
 8. Proxy status: DNS only (gray cloud icon)
 9. Click Save
 
@@ -64,7 +64,7 @@ A CNAME record was added in the DNS provider's control panel:
 3. Click "Add" under Records
 4. Type: `CNAME`
 5. Host: `dnf`
-6. Points to: `xibo-players.github.io`
+6. Points to: `xiboplayer.github.io`
 7. TTL: 1 Hour
 8. Click Save
 
@@ -75,7 +75,7 @@ A CNAME record was added in the DNS provider's control panel:
 4. Add New Record
 5. Type: `CNAME Record`
 6. Host: `dnf`
-7. Value: `xibo-players.github.io.`
+7. Value: `xiboplayer.github.io.`
 8. Click Save
 
 ### Verify DNS Propagation
@@ -90,7 +90,7 @@ nslookup dl.xiboplayer.org
 dig dl.xiboplayer.org CNAME +short
 ```
 
-Expected output: `xibo-players.github.io.`
+Expected output: `xiboplayer.github.io.`
 
 ## Step 2: Configure GitHub Pages Custom Domain (✅ Completed)
 
@@ -98,7 +98,7 @@ The custom domain has been configured in GitHub Pages settings.
 
 ### Via GitHub Web Interface
 
-1. Go to repository: https://github.com/xibo-players/.github
+1. Go to repository: https://github.com/xiboplayer/.github
 2. Navigate to **Settings** → **Pages**
 3. Under "Custom domain", enter: `dl.xiboplayer.org`
 4. Click **Save**
@@ -136,7 +136,7 @@ All documentation files have been updated to reference the custom domain:
 
 **Before:**
 ```
-https://xibo-players.github.io/.github/rpm/
+https://xiboplayer.github.io/.github/rpm/
 ```
 
 **After:**
@@ -195,7 +195,7 @@ dnf repoquery --repofrompath=xibo,https://dl.xiboplayer.org/rpm/fedora/43/x86_64
 
 Now that the custom domain is active, users enjoy:
 
-✅ **Cleaner URLs**: `dl.xiboplayer.org` vs `xibo-players.github.io/.github`  
+✅ **Cleaner URLs**: `dl.xiboplayer.org` vs `xiboplayer.github.io/.github`  
 ✅ **Professional appearance**: Branded domain name  
 ✅ **Easier to remember**: Simple, intuitive URL structure  
 ✅ **Better SEO**: Custom domain improves search visibility  
@@ -218,8 +218,8 @@ For reference or to set up additional custom domains, the complete setup process
 **Solutions:**
 1. Wait longer - DNS can take up to 48 hours to propagate globally
 2. Check your DNS provider's control panel for typos
-3. Ensure CNAME points to `xibo-players.github.io` (not `.github`)
-4. Some providers need trailing dot: `xibo-players.github.io.`
+3. Ensure CNAME points to `xiboplayer.github.io` (not `.github`)
+4. Some providers need trailing dot: `xiboplayer.github.io.`
 
 ### GitHub Pages Shows "Domain's DNS record could not be retrieved"
 
@@ -230,7 +230,7 @@ For reference or to set up additional custom domains, the complete setup process
 2. Temporarily disable "Enforce HTTPS"
 3. Remove and re-add the custom domain
 4. Check DNS with `dig dl.xiboplayer.org CNAME +short`
-5. Ensure CNAME points to `xibo-players.github.io` (not the full path)
+5. Ensure CNAME points to `xiboplayer.github.io` (not the full path)
 
 ### HTTPS Certificate Issues
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -4,7 +4,7 @@
 
 To publish the GitHub Pages site for this repository:
 
-1. **Go to Actions tab**: https://github.com/xibo-players/.github/actions
+1. **Go to Actions tab**: https://github.com/xiboplayer/.github/actions
 2. **Select workflow**: "Publish GitHub Pages"
 3. **Click**: "Run workflow"
 4. **Wait**: ~1 minute for completion

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo dnf install xiboplayer-electron
 
 ```bash
 # Add repository
-echo "deb [trusted=yes] https://xibo-players.github.io/.github/deb/ubuntu/24.04 ./" | sudo tee /etc/apt/sources.list.d/xibo-players.list
+echo "deb [trusted=yes] https://xiboplayer.github.io/.github/deb/ubuntu/24.04 ./" | sudo tee /etc/apt/sources.list.d/xibo-players.list
 sudo apt-get update
 
 # Install packages
@@ -56,7 +56,7 @@ on:
 
 jobs:
   build-rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@main
     with:
       package-name: 'xiboplayer-electron'
       build-command: 'pnpm run build:linux'
@@ -70,7 +70,7 @@ jobs:
 ```yaml
 jobs:
   build-rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@main
     with:
       package-name: 'xiboplayer-electron'
       build-command: 'pnpm run build:linux'
@@ -132,7 +132,7 @@ Release:        1%{?dist}
 Summary:        Xibo Player Electron Application
 
 License:        AGPLv3+
-URL:            https://github.com/xibo-players/xiboplayer-electron
+URL:            https://github.com/xiboplayer/xiboplayer-electron
 Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      x86_64
@@ -235,7 +235,7 @@ on:
 
 jobs:
   build-deb:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@main
     with:
       package-name: 'xiboplayer-electron'
       build-command: 'pnpm run build:linux'
@@ -276,7 +276,7 @@ Once your DEBs are published, users can install them from your gh-pages reposito
 
 ```bash
 # Add the repository
-echo "deb [trusted=yes] https://xibo-players.github.io/.github/deb/ubuntu/24.04 ./" | sudo tee /etc/apt/sources.list.d/xibo-players.list
+echo "deb [trusted=yes] https://xiboplayer.github.io/.github/deb/ubuntu/24.04 ./" | sudo tee /etc/apt/sources.list.d/xibo-players.list
 sudo apt-get update
 
 # Install your package
@@ -300,7 +300,7 @@ on:
 
 jobs:
   build-pwa:
-    uses: xibo-players/.github/.github/workflows/build-pwa.yml@main
+    uses: xiboplayer/.github/.github/workflows/build-pwa.yml@main
     with:
       node-version: '22'
       build-command: 'pnpm run build'
@@ -338,7 +338,7 @@ on:
 
 jobs:
   publish:
-    uses: xibo-players/.github/.github/workflows/publish-npm.yml@main
+    uses: xiboplayer/.github/.github/workflows/publish-npm.yml@main
     with:
       node-version: '22'
       publish-command: 'pnpm publish --no-git-checks --access public'
@@ -385,7 +385,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@<pinned-sha>
+    uses: xiboplayer/.github/.github/workflows/build-iso.yml@<pinned-sha>
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'
@@ -489,7 +489,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@<pinned-sha>
+    uses: xiboplayer/.github/.github/workflows/build-iso.yml@<pinned-sha>
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'
@@ -569,7 +569,7 @@ on:
 
 jobs:
   test:
-    uses: xibo-players/.github/.github/workflows/test.yml@main
+    uses: xiboplayer/.github/.github/workflows/test.yml@main
     with:
       node-version: '22'
       test-command: 'pnpm test'
@@ -610,14 +610,14 @@ on:
 
 jobs:
   test:
-    uses: xibo-players/.github/.github/workflows/test.yml@main
+    uses: xiboplayer/.github/.github/workflows/test.yml@main
     with:
       node-version: '22'
 
   build-rpm:
     needs: test
     if: github.event_name != 'pull_request'
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@main
     with:
       package-name: 'my-package'
       build-command: 'pnpm run build:linux'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ discretion.
 ## Scope
 
 This policy applies to all repositories in the
-[xibo-players](https://github.com/xibo-players) organisation. For
+[xibo-players](https://github.com/xiboplayer) organisation. For
 vulnerabilities in upstream Xibo CMS, please report to the Xibo project at
 [xibosignage/xibo-cms](https://github.com/xibosignage/xibo-cms).
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -16,7 +16,7 @@ Download a ready-made kiosk image. Flash to USB or SD card, boot and your displa
 
 Flash to USB, boot.<br>Fully offline — no network needed.
 
-[Download ISO](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)
+[Download ISO](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)
 
 </td>
 <td width="25%" align="center" valign="top">
@@ -25,7 +25,7 @@ Flash to USB, boot.<br>Fully offline — no network needed.
 
 Flash `.raw.xz` to SD card.<br>Insert, power on, done.
 
-[Download image](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)
+[Download image](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)
 
 </td>
 <td width="25%" align="center" valign="top">
@@ -34,7 +34,7 @@ Flash `.raw.xz` to SD card.<br>Insert, power on, done.
 
 Open in GNOME Boxes,<br>virt-manager or QEMU.
 
-[Download QCOW2](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)
+[Download QCOW2](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)
 
 </td>
 <td width="25%" align="center" valign="top">
@@ -43,7 +43,7 @@ Open in GNOME Boxes,<br>virt-manager or QEMU.
 
 Flash to SSD or eMMC.<br>Works on any x86_64 board.
 
-[Download image](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)
+[Download image](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)
 
 </td>
 </tr>
@@ -84,11 +84,11 @@ Multiple player implementations to fit your hardware and use case.
 
 | Player | Description | Platforms |
 |--------|-------------|-----------|
-| [**Electron**](https://github.com/xibo-players/xiboplayer-electron) | Full-featured desktop app with GPU acceleration and multi-instance support | RPM, DEB — x86_64, aarch64 |
-| [**Chromium Kiosk**](https://github.com/xibo-players/xiboplayer-chromium) | Lightweight — uses system Chromium, smallest footprint (~5 MB) | RPM, DEB — noarch |
-| [**PWA**](https://github.com/xibo-players/xiboplayer/tree/main/packages/pwa) | Browser-based player — open a URL, zero installation | Any modern browser |
-| [**arexibo**](https://github.com/xibo-players/arexibo) | Native Rust player with Qt6 WebEngine and serial port control | RPM, DEB — x86_64, aarch64 |
-| [**Kiosk**](https://github.com/xibo-players/xiboplayer-kiosk) | Complete kiosk OS — GNOME Kiosk session, auto-login, health monitoring | ISO, QCOW2, raw images |
+| [**Electron**](https://github.com/xiboplayer/xiboplayer-electron) | Full-featured desktop app with GPU acceleration and multi-instance support | RPM, DEB — x86_64, aarch64 |
+| [**Chromium Kiosk**](https://github.com/xiboplayer/xiboplayer-chromium) | Lightweight — uses system Chromium, smallest footprint (~5 MB) | RPM, DEB — noarch |
+| [**PWA**](https://github.com/xiboplayer/xiboplayer/tree/main/packages/pwa) | Browser-based player — open a URL, zero installation | Any modern browser |
+| [**arexibo**](https://github.com/xiboplayer/arexibo) | Native Rust player with Qt6 WebEngine and serial port control | RPM, DEB — x86_64, aarch64 |
+| [**Kiosk**](https://github.com/xiboplayer/xiboplayer-kiosk) | Complete kiosk OS — GNOME Kiosk session, auto-login, health monitoring | ISO, QCOW2, raw images |
 
 Switch players at any time: `doas alternatives --config xiboplayer`
 
@@ -98,7 +98,7 @@ Switch players at any time: `doas alternatives --config xiboplayer`
 
 ## SDK
 
-All players are built on the **[@xiboplayer SDK](https://github.com/xibo-players/xiboplayer)** — 14 modular TypeScript packages for building digital signage applications.
+All players are built on the **[@xiboplayer SDK](https://github.com/xiboplayer/xiboplayer)** — 14 modular TypeScript packages for building digital signage applications.
 
 Caching, rendering, scheduling, CMS communication (SOAP + REST), XMR real-time commands, multi-display sync and more.
 

--- a/scripts/mkosi/kickstart/xibo-kiosk.ks.template
+++ b/scripts/mkosi/kickstart/xibo-kiosk.ks.template
@@ -96,7 +96,7 @@ dnf swap -y ffmpeg-free ffmpeg --allowerasing || true
 # cat > /etc/yum.repos.d/xiboplayer.repo << 'EOF'
 # [xiboplayer]
 # name=Xibo Player
-# baseurl=https://xibo-players.github.io/.github/rpm/packages/
+# baseurl=https://xiboplayer.github.io/.github/rpm/packages/
 # enabled=1
 # gpgcheck=0
 # EOF

--- a/scripts/setup-repo.sh
+++ b/scripts/setup-repo.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Setup Xibo Players RPM Repository
 # ==================================
-# This script configures your Fedora/RHEL system to use the xibo-players RPM repository
+# This script configures your Fedora/RHEL system to use the xiboplayer RPM repository
 
 set -e
 
-REPO_NAME="xibo-players"
+REPO_NAME="xiboplayer"
 REPO_URL="https://dl.xiboplayer.org/rpm/fedora/\$releasever/\$basearch/"
 REPO_FILE="/etc/yum.repos.d/${REPO_NAME}.repo"
 
@@ -72,7 +72,7 @@ echo "==================================="
 echo "✓ Setup complete!"
 echo "==================================="
 echo ""
-echo "You can now install packages from the xibo-players repository:"
+echo "You can now install packages from the xiboplayer repository:"
 echo ""
 echo "  dnf search xibo"
 echo "  dnf install <package-name>"


### PR DESCRIPTION
GH org renamed; GraphQL/workflow-context/npm-scope don't follow redirects. Pure rename sweep, symmetric diff. Companion sweep across all sibling repos.