### PR TITLE
ci(cleanup-releases): use bundled AWS CLI installer on Ubuntu 24.04

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -53,7 +53,11 @@ jobs:
         if: inputs.r2-prefix != '' || inputs.r2-atomic-prefix != ''
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y awscli jq
+          sudo apt-get install -y -qq unzip jq
+          curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          sudo /tmp/aws/install --update
+          aws --version
 
       - name: Clean versioned GitHub Releases (v*)
         env:


### PR DESCRIPTION
Closes #45.

## Summary

Replace `apt-get install -y awscli` (which now fails with `Package 'awscli' has no installation candidate` on Ubuntu 24.04 noble — see #45 for the full failure log) with the official AWS v2 bundled installer.

## Test plan

- [x] yamllint on `cleanup-releases.yml` — no new findings introduced (pre-existing warnings on unrelated lines remain).
- [ ] After merge: confirm next scheduled `xiboplayer-kiosk` cleanup run (06:30 UTC daily) completes green.
- [ ] Confirm `aws --version` line prints a `2.x` version string in the run log.

## Risk

Low. Tiny scoped diff (5 +/- 1 line). Affects only the install-tools step before any S3 / GH-API call. If the awscli download fails the step fails-loud (same as today, but with a clearer error).